### PR TITLE
レコードの取得実装

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-	id 'org.springframework.boot' version '2.2.8.BUILD-SNAPSHOT'
-	id 'io.spring.dependency-management' version '1.0.9.RELEASE'
-	id 'java'
+    id 'org.springframework.boot' version '2.2.8.BUILD-SNAPSHOT'
+    id 'io.spring.dependency-management' version '1.0.9.RELEASE'
+    id 'java'
 }
 
 group = 'jp.yoshikipom'
@@ -9,34 +9,35 @@ version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
 configurations {
-	developmentOnly
-	runtimeClasspath {
-		extendsFrom developmentOnly
-	}
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    developmentOnly
+    runtimeClasspath {
+        extendsFrom developmentOnly
+    }
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
-	maven { url 'https://repo.spring.io/milestone' }
-	maven { url 'https://repo.spring.io/snapshot' }
+    mavenCentral()
+    maven { url 'https://repo.spring.io/milestone' }
+    maven { url 'https://repo.spring.io/snapshot' }
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.1.2'
-	implementation 'com.h2database:h2'
-	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation('org.springframework.boot:spring-boot-starter-test') {
-		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
-	}
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.1.2'
+    implementation 'com.h2database:h2'
+    compile 'commons-io:commons-io'
+    compileOnly 'org.projectlombok:lombok'
+    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation('org.springframework.boot:spring-boot-starter-test') {
+        exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
+    }
 }
 
 test {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/jp/yoshikipom/runlogapi/app/controller/RecordController.java
+++ b/src/main/java/jp/yoshikipom/runlogapi/app/controller/RecordController.java
@@ -1,0 +1,24 @@
+package jp.yoshikipom.runlogapi.app.controller;
+
+import java.util.List;
+import jp.yoshikipom.runlogapi.domain.model.Record;
+import jp.yoshikipom.runlogapi.domain.service.RecordService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/records")
+public class RecordController {
+
+  private RecordService recordService;
+
+  public RecordController(RecordService recordService) {
+    this.recordService = recordService;
+  }
+
+  @GetMapping("")
+  List<Record> getList() {
+    return this.recordService.findRecords();
+  }
+}

--- a/src/main/java/jp/yoshikipom/runlogapi/domain/model/Record.java
+++ b/src/main/java/jp/yoshikipom/runlogapi/domain/model/Record.java
@@ -1,0 +1,18 @@
+package jp.yoshikipom.runlogapi.domain.model;
+
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Record {
+
+  private LocalDate date;
+  private float distance;
+  private String memo;
+}

--- a/src/main/java/jp/yoshikipom/runlogapi/domain/repo/RecordRepo.java
+++ b/src/main/java/jp/yoshikipom/runlogapi/domain/repo/RecordRepo.java
@@ -1,0 +1,9 @@
+package jp.yoshikipom.runlogapi.domain.repo;
+
+import java.util.List;
+import jp.yoshikipom.runlogapi.domain.model.Record;
+
+public interface RecordRepo {
+
+  List<Record> findRecords();
+}

--- a/src/main/java/jp/yoshikipom/runlogapi/domain/service/RecordService.java
+++ b/src/main/java/jp/yoshikipom/runlogapi/domain/service/RecordService.java
@@ -1,0 +1,20 @@
+package jp.yoshikipom.runlogapi.domain.service;
+
+import java.util.List;
+import jp.yoshikipom.runlogapi.domain.model.Record;
+import jp.yoshikipom.runlogapi.domain.repo.RecordRepo;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RecordService {
+
+  private RecordRepo recordRepo;
+
+  public RecordService(RecordRepo recordRepo) {
+    this.recordRepo = recordRepo;
+  }
+
+  public List<Record> findRecords() {
+    return this.recordRepo.findRecords();
+  }
+}

--- a/src/main/java/jp/yoshikipom/runlogapi/infra/RecordRepoDummy.java
+++ b/src/main/java/jp/yoshikipom/runlogapi/infra/RecordRepoDummy.java
@@ -1,0 +1,30 @@
+package jp.yoshikipom.runlogapi.infra;
+
+import java.time.LocalDate;
+import java.util.List;
+import jp.yoshikipom.runlogapi.domain.model.Record;
+import jp.yoshikipom.runlogapi.domain.repo.RecordRepo;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class RecordRepoDummy implements RecordRepo {
+
+
+  @Override
+  public List<Record> findRecords() {
+    var record1 = Record.builder()
+        .date(LocalDate.now())
+        .distance(10)
+        .memo("test memo1")
+        .build();
+
+    var record2 = Record.builder()
+        .date(LocalDate.now().plusDays(-1))
+        .distance(5)
+        .memo("test memo2")
+        .build();
+
+    return List.of(record1, record2);
+  }
+
+}

--- a/src/test/java/jp/yoshikipom/runlogapi/TestUtil.java
+++ b/src/test/java/jp/yoshikipom/runlogapi/TestUtil.java
@@ -1,0 +1,19 @@
+package jp.yoshikipom.runlogapi;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import org.apache.commons.io.IOUtils;
+import org.springframework.core.io.ClassPathResource;
+
+public class TestUtil {
+
+  public String readFile(final String path) {
+    try {
+      return IOUtils
+          .toString(new ClassPathResource(path).getInputStream(), Charset.defaultCharset());
+    } catch (IOException e) {
+      e.printStackTrace();
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/test/java/jp/yoshikipom/runlogapi/app/controller/RecordControllerTest.java
+++ b/src/test/java/jp/yoshikipom/runlogapi/app/controller/RecordControllerTest.java
@@ -1,0 +1,30 @@
+package jp.yoshikipom.runlogapi.app.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import jp.yoshikipom.runlogapi.TestUtil;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class RecordControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Test
+  void getList_success() throws Exception {
+    String expectedResponse = new TestUtil().readFile("data/app/response/records-200.json");
+
+    this.mockMvc.perform(get("/records"))
+        .andExpect(status().is2xxSuccessful())
+        .andExpect(content().json(expectedResponse));
+  }
+
+}

--- a/src/test/java/jp/yoshikipom/runlogapi/domain/service/RecordServiceTest.java
+++ b/src/test/java/jp/yoshikipom/runlogapi/domain/service/RecordServiceTest.java
@@ -34,5 +34,4 @@ class RecordServiceTest {
     var actual = target.findRecords();
     assertEquals(dummyRecords, actual);
   }
-
 }

--- a/src/test/java/jp/yoshikipom/runlogapi/domain/service/RecordServiceTest.java
+++ b/src/test/java/jp/yoshikipom/runlogapi/domain/service/RecordServiceTest.java
@@ -1,0 +1,38 @@
+package jp.yoshikipom.runlogapi.domain.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import jp.yoshikipom.runlogapi.domain.model.Record;
+import jp.yoshikipom.runlogapi.domain.repo.RecordRepo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+@SpringBootTest
+class RecordServiceTest {
+
+  @Autowired
+  private RecordService target;
+  @MockBean
+  private RecordRepo recordRepo;
+
+  @Mock
+  private List<Record> dummyRecords;
+
+  @BeforeEach
+  void setUp() {
+    when(recordRepo.findRecords()).thenReturn(dummyRecords);
+  }
+
+  @Test
+  void findRecords_success() {
+    var actual = target.findRecords();
+    assertEquals(dummyRecords, actual);
+  }
+
+}

--- a/src/test/resources/data/app/response/records-200.json
+++ b/src/test/resources/data/app/response/records-200.json
@@ -1,0 +1,12 @@
+[
+  {
+    "date": "2020-05-30",
+    "distance": 10,
+    "memo": "test memo1"
+  },
+  {
+    "date": "2020-05-29",
+    "distance": 5,
+    "memo": "test memo2"
+  }
+]


### PR DESCRIPTION
# 概要
ある日の登録データを取得するエンドポイントを実装
path: `/records`
method: get

以下のガイドラインを参考にレイヤ化したフォルダ構造に。
一旦infra部分はdummy実装。

> 本ガイドラインでは、アプリケーションを、次の3レイヤで分割する。
    アプリケーション層
    ドメイン層
    インフラストラクチャ層
https://terasolunaorg.github.io/guideline/public_review/Overview/ApplicationLayering.html

# 動作確認
```
yoshiki@yoshiki:runlog/runlogapi ‹get-records*›$ curl localhost:8080/records |jq 
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   116    0   116    0     0   8285      0 --:--:-- --:--:-- --:--:--  8285
[
  {
    "date": "2020-05-30",
    "distance": 10,
    "memo": "test memo1"
  },
  {
    "date": "2020-05-29",
    "distance": 5,
    "memo": "test memo2"
  }
]
```