### PR TITLE
共通のエラーハンドリング実装

### DIFF
--- a/src/main/java/jp/yoshikipom/runlogapi/app/controller/ErrorController.java
+++ b/src/main/java/jp/yoshikipom/runlogapi/app/controller/ErrorController.java
@@ -1,0 +1,28 @@
+package jp.yoshikipom.runlogapi.app.controller;
+
+import javax.servlet.http.HttpServletRequest;
+import jp.yoshikipom.runlogapi.app.response.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class ErrorController {
+
+  // 予想外のエラーはここでハンドリング
+  @ExceptionHandler(Exception.class)
+  @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+  public ErrorResponse handleServerError(HttpServletRequest req, Exception e) {
+    log.error("system error.", e);
+    return ErrorResponse.builder()
+        .status(HttpStatus.INTERNAL_SERVER_ERROR.value())
+        .error(HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase())
+        .message(e.getMessage())
+        .path(req.getRequestURI())
+        .build();
+  }
+
+}

--- a/src/main/java/jp/yoshikipom/runlogapi/app/controller/ErrorController.java
+++ b/src/main/java/jp/yoshikipom/runlogapi/app/controller/ErrorController.java
@@ -29,7 +29,7 @@ public class ErrorController {
 
   @ExceptionHandler({NoHandlerFoundException.class, NotFoundException.class})
   @ResponseStatus(HttpStatus.NOT_FOUND)
-  public ErrorResponse handleNotFOund(HttpServletRequest req, Exception e) {
+  public ErrorResponse handleNotFound(HttpServletRequest req, Exception e) {
     log.info("bad request.", e);
     return ErrorResponse.builder()
         .status(HttpStatus.NOT_FOUND.value())
@@ -47,7 +47,7 @@ public class ErrorController {
     return ErrorResponse.builder()
         .status(HttpStatus.INTERNAL_SERVER_ERROR.value())
         .error(HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase())
-        .message(e.getMessage())
+        .message("Unexpected error")
         .path(req.getRequestURI())
         .build();
   }

--- a/src/main/java/jp/yoshikipom/runlogapi/app/controller/ErrorController.java
+++ b/src/main/java/jp/yoshikipom/runlogapi/app/controller/ErrorController.java
@@ -2,12 +2,14 @@ package jp.yoshikipom.runlogapi.app.controller;
 
 import javax.servlet.http.HttpServletRequest;
 import jp.yoshikipom.runlogapi.app.exception.BadRequestException;
+import jp.yoshikipom.runlogapi.app.exception.NotFoundException;
 import jp.yoshikipom.runlogapi.app.response.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
 
 @RestControllerAdvice
 @Slf4j
@@ -20,6 +22,18 @@ public class ErrorController {
     return ErrorResponse.builder()
         .status(HttpStatus.BAD_REQUEST.value())
         .error(HttpStatus.BAD_REQUEST.getReasonPhrase())
+        .message(e.getMessage())
+        .path(req.getRequestURI())
+        .build();
+  }
+
+  @ExceptionHandler({NoHandlerFoundException.class, NotFoundException.class})
+  @ResponseStatus(HttpStatus.NOT_FOUND)
+  public ErrorResponse handleNotFOund(HttpServletRequest req, Exception e) {
+    log.info("bad request.", e);
+    return ErrorResponse.builder()
+        .status(HttpStatus.NOT_FOUND.value())
+        .error(HttpStatus.NOT_FOUND.getReasonPhrase())
         .message(e.getMessage())
         .path(req.getRequestURI())
         .build();

--- a/src/main/java/jp/yoshikipom/runlogapi/app/controller/ErrorController.java
+++ b/src/main/java/jp/yoshikipom/runlogapi/app/controller/ErrorController.java
@@ -1,6 +1,7 @@
 package jp.yoshikipom.runlogapi.app.controller;
 
 import javax.servlet.http.HttpServletRequest;
+import jp.yoshikipom.runlogapi.app.exception.BadRequestException;
 import jp.yoshikipom.runlogapi.app.response.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -11,6 +12,18 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 @Slf4j
 public class ErrorController {
+
+  @ExceptionHandler(BadRequestException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  public ErrorResponse handleBadRequest(HttpServletRequest req, Exception e) {
+    log.info("bad request.", e);
+    return ErrorResponse.builder()
+        .status(HttpStatus.BAD_REQUEST.value())
+        .error(HttpStatus.BAD_REQUEST.getReasonPhrase())
+        .message(e.getMessage())
+        .path(req.getRequestURI())
+        .build();
+  }
 
   // 予想外のエラーはここでハンドリング
   @ExceptionHandler(Exception.class)

--- a/src/main/java/jp/yoshikipom/runlogapi/app/controller/RecordController.java
+++ b/src/main/java/jp/yoshikipom/runlogapi/app/controller/RecordController.java
@@ -4,12 +4,10 @@ import java.util.List;
 import jp.yoshikipom.runlogapi.domain.model.Record;
 import jp.yoshikipom.runlogapi.domain.service.RecordService;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("")
 public class RecordController {
 
   private RecordService recordService;

--- a/src/main/java/jp/yoshikipom/runlogapi/app/exception/BadRequestException.java
+++ b/src/main/java/jp/yoshikipom/runlogapi/app/exception/BadRequestException.java
@@ -1,0 +1,8 @@
+package jp.yoshikipom.runlogapi.app.exception;
+
+public class BadRequestException extends RuntimeException {
+
+  public BadRequestException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/jp/yoshikipom/runlogapi/app/exception/NotFoundException.java
+++ b/src/main/java/jp/yoshikipom/runlogapi/app/exception/NotFoundException.java
@@ -1,0 +1,8 @@
+package jp.yoshikipom.runlogapi.app.exception;
+
+public class NotFoundException extends RuntimeException {
+
+  public NotFoundException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/jp/yoshikipom/runlogapi/app/response/ErrorResponse.java
+++ b/src/main/java/jp/yoshikipom/runlogapi/app/response/ErrorResponse.java
@@ -1,0 +1,21 @@
+package jp.yoshikipom.runlogapi.app.response;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ErrorResponse {
+
+  @Builder.Default
+  private LocalDateTime timestamp = LocalDateTime.now();
+  private int status;
+  private String error;
+  private String message;
+  private String path;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,8 @@
 spring:
+  mvc:
+    throw-exception-if-no-handler-found: true
+  resources:
+    add-mappings: false
   datasource:
     driver-class-name: org.h2.Driver
     url: jdbc:h2:mem:runlog;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MODE=MYSQL

--- a/src/test/java/jp/yoshikipom/runlogapi/ErrorControllerMock.java
+++ b/src/test/java/jp/yoshikipom/runlogapi/ErrorControllerMock.java
@@ -1,0 +1,15 @@
+package jp.yoshikipom.runlogapi;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/error")
+public class ErrorControllerMock {
+
+  @GetMapping("/500")
+  public void internalServerError() {
+    throw new RuntimeException("error-message");
+  }
+}

--- a/src/test/java/jp/yoshikipom/runlogapi/ErrorControllerMock.java
+++ b/src/test/java/jp/yoshikipom/runlogapi/ErrorControllerMock.java
@@ -1,6 +1,7 @@
 package jp.yoshikipom.runlogapi;
 
 import jp.yoshikipom.runlogapi.app.exception.BadRequestException;
+import jp.yoshikipom.runlogapi.app.exception.NotFoundException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -12,6 +13,11 @@ public class ErrorControllerMock {
   @GetMapping("/400")
   public void badRequest() {
     throw new BadRequestException("error-message", new Exception());
+  }
+
+  @GetMapping("/404")
+  public void notFound() {
+    throw new NotFoundException("error-message", new Exception());
   }
 
   @GetMapping("/500")

--- a/src/test/java/jp/yoshikipom/runlogapi/ErrorControllerMock.java
+++ b/src/test/java/jp/yoshikipom/runlogapi/ErrorControllerMock.java
@@ -1,5 +1,6 @@
 package jp.yoshikipom.runlogapi;
 
+import jp.yoshikipom.runlogapi.app.exception.BadRequestException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -7,6 +8,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/error")
 public class ErrorControllerMock {
+
+  @GetMapping("/400")
+  public void badRequest() {
+    throw new BadRequestException("error-message", new Exception());
+  }
 
   @GetMapping("/500")
   public void internalServerError() {

--- a/src/test/java/jp/yoshikipom/runlogapi/app/controller/ErrorControllerTest.java
+++ b/src/test/java/jp/yoshikipom/runlogapi/app/controller/ErrorControllerTest.java
@@ -18,6 +18,16 @@ class ErrorControllerTest {
   private MockMvc mockMvc;
 
   @Test
+  void handleBadRequest_success() throws Exception {
+    mockMvc.perform(get("/error/400"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("status").value(400))
+        .andExpect(jsonPath("error").value("Bad Request"))
+        .andExpect(jsonPath("message").value("error-message"))
+        .andExpect(jsonPath("path").value("/error/400"));
+  }
+
+  @Test
   void handleServerError_success() throws Exception {
     mockMvc.perform(get("/error/500"))
         .andExpect(status().isInternalServerError())

--- a/src/test/java/jp/yoshikipom/runlogapi/app/controller/ErrorControllerTest.java
+++ b/src/test/java/jp/yoshikipom/runlogapi/app/controller/ErrorControllerTest.java
@@ -28,6 +28,26 @@ class ErrorControllerTest {
   }
 
   @Test
+  void handleNotFound_success() throws Exception {
+    mockMvc.perform(get("/error/404"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("status").value(404))
+        .andExpect(jsonPath("error").value("Not Found"))
+        .andExpect(jsonPath("message").value("error-message"))
+        .andExpect(jsonPath("path").value("/error/404"));
+  }
+
+  @Test
+  void handleNotFound_noHandler_success() throws Exception {
+    mockMvc.perform(get("/not-found-path"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("status").value(404))
+        .andExpect(jsonPath("error").value("Not Found"))
+        .andExpect(jsonPath("message").value("No handler found for GET /not-found-path"))
+        .andExpect(jsonPath("path").value("/not-found-path"));
+  }
+
+  @Test
   void handleServerError_success() throws Exception {
     mockMvc.perform(get("/error/500"))
         .andExpect(status().isInternalServerError())

--- a/src/test/java/jp/yoshikipom/runlogapi/app/controller/ErrorControllerTest.java
+++ b/src/test/java/jp/yoshikipom/runlogapi/app/controller/ErrorControllerTest.java
@@ -53,7 +53,7 @@ class ErrorControllerTest {
         .andExpect(status().isInternalServerError())
         .andExpect(jsonPath("status").value(500))
         .andExpect(jsonPath("error").value("Internal Server Error"))
-        .andExpect(jsonPath("message").value("error-message"))
+        .andExpect(jsonPath("message").value("Unexpected error"))
         .andExpect(jsonPath("path").value("/error/500"));
   }
 }

--- a/src/test/java/jp/yoshikipom/runlogapi/app/controller/ErrorControllerTest.java
+++ b/src/test/java/jp/yoshikipom/runlogapi/app/controller/ErrorControllerTest.java
@@ -1,0 +1,29 @@
+package jp.yoshikipom.runlogapi.app.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ErrorControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Test
+  void handleServerError_success() throws Exception {
+    mockMvc.perform(get("/error/500"))
+        .andExpect(status().isInternalServerError())
+        .andExpect(jsonPath("status").value(500))
+        .andExpect(jsonPath("error").value("Internal Server Error"))
+        .andExpect(jsonPath("message").value("error-message"))
+        .andExpect(jsonPath("path").value("/error/500"));
+  }
+}


### PR DESCRIPTION
Controllerから投げられる例外に応じて専用のレスポンスを返すようにした。

専用例外 `NotFoundException` , `BadRequestException` , パスが見つからない時の `NoHandlerFoundException` 以外は500になる。

以下、500の例。 （実際は以下のリクエストはBadRequestにすべきだが未実装）
messageはException#getMessage()の内容がはいる実装。
``` 
yoshiki@yoshiki:~ $ curl "http://localhost:8080/monthRecords?year=2020" |jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   168    0   168    0     0  16800      0 --:--:-- --:--:-- --:--:-- 16800
{
  "timestamp": "2020-06-04T08:55:50.741822",
  "status": 500,
  "error": "Internal Server Error",
  "message": "Required int parameter 'month' is not present",
  "path": "/monthRecords"
}
```

```
yoshiki@yoshiki:~ $ curl "http://localhost:8080/not-found-path" |jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   153    0   153    0     0    905      0 --:--:-- --:--:-- --:--:--   905
{
  "timestamp": "2020-06-04T08:55:41.695222",
  "status": 404,
  "error": "Not Found",
  "message": "No handler found for GET /not-found-path",
  "path": "/not-found-path"
}
```