### PR TITLE
Deleteの実装

### DIFF
--- a/src/main/java/jp/yoshikipom/runlogapi/app/controller/RecordController.java
+++ b/src/main/java/jp/yoshikipom/runlogapi/app/controller/RecordController.java
@@ -9,7 +9,9 @@ import org.modelmapper.ModelMapper;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -40,6 +42,12 @@ public class RecordController {
     }
     Record record = modelMapper.map(request, Record.class);
     return this.recordService.register(record);
+  }
+
+  @DeleteMapping("/records/{id}")
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  void deleteRecord(@PathVariable("id") Integer id) {
+    this.recordService.unregister(id);
   }
 
   @GetMapping("/monthRecords")

--- a/src/main/java/jp/yoshikipom/runlogapi/app/controller/RecordController.java
+++ b/src/main/java/jp/yoshikipom/runlogapi/app/controller/RecordController.java
@@ -6,6 +6,7 @@ import jp.yoshikipom.runlogapi.app.request.RecordRequest;
 import jp.yoshikipom.runlogapi.domain.model.Record;
 import jp.yoshikipom.runlogapi.domain.service.RecordService;
 import org.modelmapper.ModelMapper;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
@@ -47,7 +48,11 @@ public class RecordController {
   @DeleteMapping("/records/{id}")
   @ResponseStatus(HttpStatus.NO_CONTENT)
   void deleteRecord(@PathVariable("id") Integer id) {
-    this.recordService.unregister(id);
+    try {
+      this.recordService.unregister(id);
+    } catch (EmptyResultDataAccessException e) {
+      throw new BadRequestException("record is not found", e);
+    }
   }
 
   @GetMapping("/monthRecords")

--- a/src/main/java/jp/yoshikipom/runlogapi/domain/repo/RecordRepo.java
+++ b/src/main/java/jp/yoshikipom/runlogapi/domain/repo/RecordRepo.java
@@ -10,4 +10,6 @@ public interface RecordRepo {
   List<Record> findRecordsByMonth(int year, int month);
 
   Record register(Record record);
+
+  void unregister(Integer id);
 }

--- a/src/main/java/jp/yoshikipom/runlogapi/domain/service/RecordService.java
+++ b/src/main/java/jp/yoshikipom/runlogapi/domain/service/RecordService.java
@@ -25,4 +25,8 @@ public class RecordService {
   public Record register(Record record) {
     return this.recordRepo.register(record);
   }
+
+  public void unregister(Integer id) {
+    this.recordRepo.unregister(id);
+  }
 }

--- a/src/main/java/jp/yoshikipom/runlogapi/infra/record/RecordRepoImpl.java
+++ b/src/main/java/jp/yoshikipom/runlogapi/infra/record/RecordRepoImpl.java
@@ -45,4 +45,9 @@ public class RecordRepoImpl implements RecordRepo {
     RecordEntity registeredEntity = this.jpaRepository.save(entity);
     return modelMapper.map(registeredEntity, Record.class);
   }
+
+  @Override
+  public void unregister(Integer id) {
+    this.jpaRepository.deleteById(id);
+  }
 }

--- a/src/test/java/jp/yoshikipom/runlogapi/app/controller/RecordControllerTest.java
+++ b/src/test/java/jp/yoshikipom/runlogapi/app/controller/RecordControllerTest.java
@@ -1,7 +1,11 @@
 package jp.yoshikipom.runlogapi.app.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -17,6 +21,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -61,6 +66,25 @@ class RecordControllerTest {
     this.mockMvc.perform(post("/records")
         .content(request)
         .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
+  void deleteRecord_success() throws Exception {
+    Integer id = 1;
+    doNothing().when(mockedService).unregister(id);
+
+    this.mockMvc.perform(delete("/records/" + id))
+        .andExpect(status().isNoContent());
+  }
+
+  @Test
+  void deleteRecord_badRequest() throws Exception {
+    Integer id = 1;
+    var error = mock(EmptyResultDataAccessException.class);
+    doThrow(error).when(mockedService).unregister(id);
+
+    this.mockMvc.perform(delete("/records/" + id))
         .andExpect(status().isBadRequest());
   }
 

--- a/src/test/java/jp/yoshikipom/runlogapi/domain/service/RecordServiceTest.java
+++ b/src/test/java/jp/yoshikipom/runlogapi/domain/service/RecordServiceTest.java
@@ -1,6 +1,8 @@
 package jp.yoshikipom.runlogapi.domain.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -44,6 +46,14 @@ class RecordServiceTest {
     when(recordRepo.register(dummyRecord)).thenReturn(createdRecord);
     var actual = target.register(dummyRecord);
     assertEquals(createdRecord, actual);
+  }
+
+  @Test
+  void unregister_success() {
+    Integer id = 1;
+    doNothing().when(recordRepo).unregister(id);
+    target.unregister(id);
+    verify(recordRepo).unregister(id);
   }
 
   @Test

--- a/src/test/java/jp/yoshikipom/runlogapi/infra/record/RecordRepoImplTest.java
+++ b/src/test/java/jp/yoshikipom/runlogapi/infra/record/RecordRepoImplTest.java
@@ -1,6 +1,7 @@
 package jp.yoshikipom.runlogapi.infra.record;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -71,5 +72,13 @@ class RecordRepoImplTest {
     var actual = target.register(record1);
 
     assertEquals(record2, actual);
+  }
+
+  @Test
+  void unregister_success() {
+    Integer id = 1;
+    doNothing().when(jpaRepository).deleteById(id);
+    target.unregister(id);
+    verify(jpaRepository).deleteById(id);
   }
 }


### PR DESCRIPTION
動作確認。
存在しないものを削除したとき400
成功したとき204
```
yoshiki@yoshiki-mbp:runlog/rest-test $ curl_header --request DELETE \
  --url http://localhost:8080/records/5
HTTP/1.1 400 
Content-Type: application/json
Transfer-Encoding: chunked
Date: Sun, 07 Jun 2020 13:12:39 GMT
Connection: close

yoshiki@yoshiki-mbp:runlog/rest-test $ curl_header --request DELETE \
  --url http://localhost:8080/records/1
HTTP/1.1 204 
Date: Sun, 07 Jun 2020 13:12:46 GMT
```